### PR TITLE
[SDM-4] Add missing target collection

### DIFF
--- a/src/main/java/com/_4dconcept/springframework/data/marklogic/repository/query/PartTreeMarklogicQuery.java
+++ b/src/main/java/com/_4dconcept/springframework/data/marklogic/repository/query/PartTreeMarklogicQuery.java
@@ -16,6 +16,7 @@
 package com._4dconcept.springframework.data.marklogic.repository.query;
 
 import com._4dconcept.springframework.data.marklogic.core.MarklogicOperations;
+import com._4dconcept.springframework.data.marklogic.core.mapping.MarklogicPersistentEntity;
 import com._4dconcept.springframework.data.marklogic.core.mapping.MarklogicPersistentProperty;
 import com._4dconcept.springframework.data.marklogic.core.query.Query;
 import org.springframework.data.mapping.context.MappingContext;
@@ -32,7 +33,7 @@ import org.springframework.data.repository.query.parser.PartTree;
 public class PartTreeMarklogicQuery extends AbstractMarklogicQuery {
 
     private final PartTree tree;
-    private final MappingContext<?, MarklogicPersistentProperty> context;
+    private final MappingContext<? extends MarklogicPersistentEntity<?>, MarklogicPersistentProperty> context;
 
     public PartTreeMarklogicQuery(MarklogicQueryMethod method, MarklogicOperations marklogicOperations) {
         super(method, marklogicOperations);
@@ -46,6 +47,11 @@ public class PartTreeMarklogicQuery extends AbstractMarklogicQuery {
     protected Query createQuery(ParameterAccessor accessor) {
         MarklogicQueryCreator creator = new MarklogicQueryCreator(tree, accessor, context);
         Query query = creator.createQuery();
+
+        Class<?> domainType = getQueryMethod().getReturnedObjectType();
+
+        String defaultCollection = context.getPersistentEntity(domainType).getDefaultCollection();
+        query.setCollection(defaultCollection);
 
         if (tree.isLimiting()) {
             query.setLimit(tree.getMaxResults());

--- a/src/test/java/com/_4dconcept/springframework/data/marklogic/repository/query/PartTreeMarklogicQueryTest.java
+++ b/src/test/java/com/_4dconcept/springframework/data/marklogic/repository/query/PartTreeMarklogicQueryTest.java
@@ -73,6 +73,12 @@ public class PartTreeMarklogicQueryTest {
     }
 
     @Test
+    public void buildQueryUseExpectedCollection() {
+        assertThat(deriveQueryFromMethod("findByLastname", "foo").getCollection(), is("Person"));
+        assertThat(deriveQueryFromMethod("findBySkills", "foo").getCollection(), is("Person"));
+    }
+
+    @Test
     public void singleFieldShouldBeConsidered() {
         Query query = deriveQueryFromMethod("findByLastname", "foo");
 


### PR DESCRIPTION
The target collection is computed against the defined collection of the method return type