### PR TITLE
Provide a 'not' operand in order to inverse query condition.

### DIFF
--- a/src/main/java/com/_4dconcept/springframework/data/marklogic/core/cts/CTSQuerySerializer.java
+++ b/src/main/java/com/_4dconcept/springframework/data/marklogic/core/cts/CTSQuerySerializer.java
@@ -82,13 +82,16 @@ public class CTSQuerySerializer {
         if (criteria != null) {
             if (criteria.getOperator() == null) {
                 return handleSimpleValue(criteria);
+            } else if (criteria.getOperator() == Criteria.Operator.not) {
+                return String.format("cts:not-query(%s)", serializeCriteria((Criteria) criteria.getCriteriaObject()));
             } else {
                 List<Criteria> criteriaList = (List<Criteria>) criteria.getCriteriaObject();
                 String ctsQueries = criteriaList.stream().map(this::serializeCriteria).collect(Collectors.joining(", "));
 
-                switch (criteria.getOperator()) {
-                    case and: return String.format("cts:and-query((%s))", ctsQueries);
-                    case or: return String.format("cts:or-query((%s))", ctsQueries);
+                if (criteria.getOperator() == Criteria.Operator.and) {
+                    return String.format("cts:and-query((%s))", ctsQueries);
+                } else if (criteria.getOperator() == Criteria.Operator.or) {
+                    return String.format("cts:or-query((%s))", ctsQueries);
                 }
             }
         }

--- a/src/main/java/com/_4dconcept/springframework/data/marklogic/core/query/Criteria.java
+++ b/src/main/java/com/_4dconcept/springframework/data/marklogic/core/query/Criteria.java
@@ -27,7 +27,7 @@ import java.util.Collection;
  */
 public class Criteria implements CriteriaDefinition {
 
-    public enum Operator {and, or}
+    public enum Operator {and, or, not}
 
     private QName qname;
     private Object criteriaObject;

--- a/src/main/java/com/_4dconcept/springframework/data/marklogic/repository/query/MarklogicQueryCreator.java
+++ b/src/main/java/com/_4dconcept/springframework/data/marklogic/repository/query/MarklogicQueryCreator.java
@@ -131,7 +131,8 @@ public class MarklogicQueryCreator extends AbstractQueryCreator<Query, Criteria>
                 return computeSimpleCriteria(property.getQName(), false);
 //            case NEAR:
 //            case WITHIN:
-//            case NEGATING_SIMPLE_PROPERTY:
+            case NEGATING_SIMPLE_PROPERTY:
+                return computeSimpleCriteria(property.getQName(), parameters.next(), true);
             case SIMPLE_PROPERTY:
                 return computeSimpleCriteria(property.getQName(), parameters.next());
             default:
@@ -140,20 +141,27 @@ public class MarklogicQueryCreator extends AbstractQueryCreator<Query, Criteria>
     }
 
     private Criteria computeContainingCriteria(QName qName, Object parameter) {
-        if (parameter instanceof List) {
-            List<?> list = (List<?>) parameter;
-            List<Criteria> criteriaList = list.stream().map(o -> new Criteria(qName, o)).collect(Collectors.toList());
-            return new Criteria(Criteria.Operator.or, criteriaList);
-        } else {
-            return new Criteria(qName, parameter);
-        }
+        return buildSimpleCriteria(qName, parameter, Criteria.Operator.or);
     }
 
     private Criteria computeSimpleCriteria(QName qName, Object parameter) {
+        return computeSimpleCriteria(qName, parameter, false);
+    }
+
+    private Criteria computeSimpleCriteria(QName qName, Object parameter, boolean inverse) {
+        Criteria criteria = buildSimpleCriteria(qName, parameter, Criteria.Operator.and);
+        if (inverse)
+            return new Criteria(Criteria.Operator.not, criteria);
+        else {
+            return criteria;
+        }
+    }
+
+    private Criteria buildSimpleCriteria(QName qName, Object parameter, Criteria.Operator groupOperator) {
         if (parameter instanceof List) {
             List<?> list = (List<?>) parameter;
             List<Criteria> criteriaList = list.stream().map(o -> new Criteria(qName, o)).collect(Collectors.toList());
-            return new Criteria(Criteria.Operator.and, criteriaList);
+            return new Criteria(groupOperator, criteriaList);
         } else {
             return new Criteria(qName, parameter);
         }

--- a/src/test/java/com/_4dconcept/springframework/data/marklogic/core/cts/CTSQuerySerializerTest.java
+++ b/src/test/java/com/_4dconcept/springframework/data/marklogic/core/cts/CTSQuerySerializerTest.java
@@ -36,14 +36,14 @@ import static org.junit.Assert.assertThat;
 public class CTSQuerySerializerTest {
 
     @Test
-    public void parseEmptyQuery() throws Exception {
+    public void parseEmptyQuery() {
         String ctsQuery = new CTSQuerySerializer(new Query()).asCtsQuery();
 
         assertThat(ctsQuery, is("cts:search(fn:collection(), (), ())"));
     }
 
     @Test
-    public void parsePopulatedQuery() throws Exception {
+    public void parsePopulatedQuery() {
         Query query = new Query();
         query.setCriteria(new Criteria(Criteria.Operator.and, Arrays.asList(
             new Criteria(new QName("name"), "Me"),
@@ -56,7 +56,17 @@ public class CTSQuerySerializerTest {
     }
 
     @Test
-    public void parseQueryWithPagination() throws Exception {
+    public void parseQueryWithNotOperator() {
+        Query query = new Query();
+        query.setCriteria(new Criteria(Criteria.Operator.not, new Criteria(new QName("town"), "Paris")));
+
+        String ctsQuery = new CTSQuerySerializer(query).asCtsQuery();
+
+        assertThat(ctsQuery, is("cts:search(fn:collection(), cts:not-query(cts:element-value-query(fn:QName('', 'town'), 'Paris')), ())"));
+    }
+
+    @Test
+    public void parseQueryWithPagination() {
         Query query = new Query();
         query.setCollection("Collection1");
         query.setLimit(10);
@@ -67,7 +77,7 @@ public class CTSQuerySerializerTest {
     }
 
     @Test
-    public void parseQueryWithSortOrders() throws Exception {
+    public void parseQueryWithSortOrders() {
         Query query = new Query();
         query.setCollection("Collection1");
         query.setSortCriteria(Arrays.asList(
@@ -80,7 +90,7 @@ public class CTSQuerySerializerTest {
     }
 
     @Test
-    public void parseQueryWithNonStringValue() throws Exception {
+    public void parseQueryWithNonStringValue() {
         Query query = new Query();
         query.setCriteria(new Criteria(new QName("age"), 38));
 
@@ -90,7 +100,7 @@ public class CTSQuerySerializerTest {
 
     // Issue #6
     @Test
-    public void parseQueryWithStringValueContainingApostropheIsEscaped() throws Exception {
+    public void parseQueryWithStringValueContainingApostropheIsEscaped() {
         Query query = new Query();
         query.setCriteria(new Criteria(new QName("name"), "l'apostrophe"));
 

--- a/src/test/java/com/_4dconcept/springframework/data/marklogic/repository/query/MarklogicQueryCreatorTest.java
+++ b/src/test/java/com/_4dconcept/springframework/data/marklogic/repository/query/MarklogicQueryCreatorTest.java
@@ -1,6 +1,7 @@
 package com._4dconcept.springframework.data.marklogic.repository.query;
 
 import com._4dconcept.springframework.data.marklogic.core.mapping.MarklogicMappingContext;
+import com._4dconcept.springframework.data.marklogic.core.query.Criteria;
 import com._4dconcept.springframework.data.marklogic.core.query.Query;
 import com._4dconcept.springframework.data.marklogic.repository.MarklogicRepository;
 import com._4dconcept.springframework.data.marklogic.repository.Person;
@@ -59,6 +60,19 @@ public class MarklogicQueryCreatorTest {
         assertThat(list, hasSize(3));
     }
 
+    @Test
+    public void createQueryWithNegativeSingleParameter() throws Exception {
+        final MarklogicQueryMethod method = buildMethod("findByAddressCountryIsNot", String.class);
+        MarklogicQueryCreator creator = new MarklogicQueryCreator(buildTree(method), buildAccessor(method, "France"), mappingContext);
+        Query query = creator.createQuery();
+
+        assertThat(query.getCriteria().getOperator(), is(Criteria.Operator.not));
+        assertThat(query.getCriteria().getCriteriaObject(), instanceOf(Criteria.class));
+        Criteria innerCriteria = (Criteria) query.getCriteria().getCriteriaObject();
+        assertThat(innerCriteria.getQname().getLocalPart(), is("country"));
+        assertThat(innerCriteria.getCriteriaObject(), is("France"));
+    }
+
     private ParameterAccessor buildAccessor(MarklogicQueryMethod method, Object... parameters) {
         return new ParametersParameterAccessor(method.getParameters(), parameters);
     }
@@ -83,6 +97,8 @@ public class MarklogicQueryCreatorTest {
         Person findByLastnameAndFirstnameAndAge(String lastname, String firstname, Integer age);
 
         Person findByAddressCountry(String country);
+
+        List<Person> findByAddressCountryIsNot(String country);
 
         List<Person> findBySkills(String skill);
 


### PR DESCRIPTION
- Implements the NEGATING_SIMPLE_PROPERTY case for MarklogicQueryCreator.
- Take ctf query serialization into account

Issues : Closes #11