### PR TITLE
[#15] Read annotated methods without parameters as any property accessor

### DIFF
--- a/src/main/java/com/_4dconcept/springframework/data/marklogic/MarklogicCollectionUtils.java
+++ b/src/main/java/com/_4dconcept/springframework/data/marklogic/MarklogicCollectionUtils.java
@@ -1,15 +1,63 @@
 package com._4dconcept.springframework.data.marklogic;
 
 import com._4dconcept.springframework.data.marklogic.core.mapping.Collection;
+import com._4dconcept.springframework.data.marklogic.core.mapping.MarklogicPersistentEntity;
 import com._4dconcept.springframework.data.marklogic.core.mapping.MarklogicPersistentProperty;
 import org.springframework.core.annotation.AnnotationUtils;
+import org.springframework.data.mapping.PersistentPropertyAccessor;
+import org.springframework.data.mapping.PropertyHandler;
+import org.springframework.data.mapping.context.MappingContext;
+import org.springframework.util.StringUtils;
 
 import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 public interface MarklogicCollectionUtils {
+
+    default <T> List<String> extractCollections(T entity, MappingContext<? extends MarklogicPersistentEntity<?>, MarklogicPersistentProperty> mappingContext) {
+        ArrayList<String> collections = new ArrayList<>();
+
+        MarklogicPersistentEntity<?> persistentEntity = mappingContext.getPersistentEntity(entity.getClass());
+        PersistentPropertyAccessor propertyAccessor = persistentEntity.getPropertyAccessor(entity);
+
+        persistentEntity.doWithProperties((PropertyHandler<MarklogicPersistentProperty>) property -> {
+            Optional<Collection> collectionAnnotation = getCollectionAnnotation(property);
+            if (collectionAnnotation.isPresent()) {
+                Object value = propertyAccessor.getProperty(property);
+                if (value != null) {
+                    collections.addAll(doWithCollectionValue(value, collectionAnnotation.get()));
+                }
+            }
+        });
+
+        for (Method method : entity.getClass().getDeclaredMethods()) {
+            if (method.getParameterCount() > 0) {
+                continue;
+            }
+
+            try {
+                Optional<Collection> collectionAnnotation = getCollectionAnnotation(method);
+                if (collectionAnnotation.isPresent()) {
+                    Object value = method.invoke(entity);
+                    if (value != null) {
+                        collections.addAll(doWithCollectionValue(value, collectionAnnotation.get()));
+                    }
+                }
+            } catch (IllegalAccessException | InvocationTargetException e) {
+                throw new UnsupportedOperationException(String.format("Unable to read value from %s", method), e);
+            }
+
+        }
+
+        return collections.stream().distinct().collect(Collectors.toList());
+    }
 
     default Optional<Collection> getCollectionAnnotation(MarklogicPersistentProperty property) {
         ArrayList<AnnotatedElement> annotatedElements = new ArrayList<>();
@@ -24,5 +72,32 @@ public interface MarklogicCollectionUtils {
 
         return annotatedElements.stream().map(e -> AnnotationUtils.findAnnotation(e, Collection.class)).filter(Objects::nonNull).findFirst();
     }
+
+    default Optional<Collection> getCollectionAnnotation(Method method) {
+        return Optional.ofNullable(AnnotationUtils.findAnnotation(method, Collection.class));
+    }
+
+    default List<String> doWithCollectionValue(Object value, Collection collection) {
+        if (value instanceof java.util.Collection) {
+            ArrayList<String> collections = new ArrayList<>();
+            java.util.Collection<?> values = (java.util.Collection<?>) value;
+            for (Object o : values) {
+                if (StringUtils.hasText(collection.prefix())) {
+                    collections.add(String.format("%s:%s", collection.prefix(), o.toString()));
+                } else {
+                    collections.add(o.toString());
+                }
+            }
+            return collections;
+        } else {
+            if (StringUtils.hasText(collection.prefix())) {
+                return Collections.singletonList(String.format("%s:%s", collection.prefix(), value.toString()));
+            } else {
+                return Collections.singletonList(value.toString());
+            }
+
+        }
+    }
+
 
 }

--- a/src/main/java/com/_4dconcept/springframework/data/marklogic/core/MarklogicTemplate.java
+++ b/src/main/java/com/_4dconcept/springframework/data/marklogic/core/MarklogicTemplate.java
@@ -57,7 +57,6 @@ import org.springframework.dao.DataAccessResourceFailureException;
 import org.springframework.dao.DataRetrievalFailureException;
 import org.springframework.dao.InvalidDataAccessApiUsageException;
 import org.springframework.data.mapping.PersistentPropertyAccessor;
-import org.springframework.data.mapping.PropertyHandler;
 import org.springframework.data.mapping.context.MappingContext;
 import org.springframework.data.mapping.model.ConvertingPropertyAccessor;
 import org.springframework.data.mapping.model.MappingException;
@@ -67,7 +66,6 @@ import org.springframework.util.CollectionUtils;
 import javax.xml.namespace.QName;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -624,28 +622,7 @@ public class MarklogicTemplate implements MarklogicOperations, ApplicationEventP
     }
 
     private <T> List<String> extractCollections(T entity) {
-        ArrayList<String> collections = new ArrayList<>();
-
-        MarklogicPersistentEntity<?> persistentEntity = mappingContext.getPersistentEntity(entity.getClass());
-        PersistentPropertyAccessor propertyAccessor = persistentEntity.getPropertyAccessor(entity);
-
-        persistentEntity.doWithProperties((PropertyHandler<MarklogicPersistentProperty>) property -> {
-            Object value = propertyAccessor.getProperty(property);
-            if (value != null && marklogicCollectionUtils.getCollectionAnnotation(property).isPresent()) {
-                if (value instanceof Collection) {
-                    Collection<?> values = (Collection<?>) value;
-                    for (Object o : values) {
-                        collections.add(o.toString());
-                    }
-                } else {
-                    collections.add(value.toString());
-                }
-
-                propertyAccessor.setProperty(property, null); // Remove the value before it is serialized
-            }
-        });
-
-        return collections;
+        return marklogicCollectionUtils.extractCollections(entity, mappingContext);
     }
 
     private void doInsertContent(Content content) {

--- a/src/test/java/com/_4dconcept/springframework/data/marklogic/MarklogicCollectionUtilsTest.java
+++ b/src/test/java/com/_4dconcept/springframework/data/marklogic/MarklogicCollectionUtilsTest.java
@@ -1,0 +1,43 @@
+package com._4dconcept.springframework.data.marklogic;
+
+import com._4dconcept.springframework.data.marklogic.core.mapping.Collection;
+import com._4dconcept.springframework.data.marklogic.core.mapping.MarklogicMappingContext;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.Assert.assertThat;
+
+public class MarklogicCollectionUtilsTest {
+
+    private MarklogicCollectionUtils marklogicCollectionUtils = new MarklogicCollectionUtils() {};
+
+    @Test
+    public void extractCollections() {
+        assertThat(marklogicCollectionUtils.extractCollections(new SampleEntity("test1", "test2"), new MarklogicMappingContext()), containsInAnyOrder("test1", "field:test2", "computed:TEST1"));
+    }
+
+    private class SampleEntity {
+
+        SampleEntity(String field1, String field2) {
+            this.field1 = field1;
+            this.field2 = field2;
+        }
+
+        @Collection
+        private String field1;
+
+        private String field2;
+
+        @Collection(prefix = "field")
+        @SuppressWarnings("unused") // Used by reflexion for test
+        public String getField2() {
+            return field2;
+        }
+
+        @Collection(prefix = "computed")
+        @SuppressWarnings("unused") // Used by reflexion for test
+        public String field1ToUpperCase() {
+            return field1.toUpperCase();
+        }
+    }
+}

--- a/src/test/java/com/_4dconcept/springframework/data/marklogic/core/MarklogicTemplateTest.java
+++ b/src/test/java/com/_4dconcept/springframework/data/marklogic/core/MarklogicTemplateTest.java
@@ -50,7 +50,6 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import javax.xml.namespace.QName;
 import java.io.InputStream;
-import java.util.Optional;
 import java.util.Scanner;
 import java.util.UUID;
 
@@ -98,9 +97,6 @@ public class MarklogicTemplateTest {
         MappingContext<BasicMarklogicPersistentEntity<?>, MarklogicPersistentProperty> marklogicMappingContext = new MarklogicMappingContext();
         when(marklogicConverter.getMappingContext()).thenReturn((MappingContext)marklogicMappingContext);
         when(marklogicConverter.getConversionService()).thenReturn(conversionService);
-
-        when(marklogicCollectionUtils.getCollectionAnnotation(any())).thenReturn(Optional.empty());
-
         when(session.submitRequest(any(Request.class))).thenReturn(resultSequence);
     }
 


### PR DESCRIPTION
Note that the method extraction is only valuable while creating content. During querying, we only need to use property or its reader.

- Refactor collection extraction : put from MarklogicTemplate to MarklogicCollectionUtils

resolve #15

