### PR TITLE
Fix deletion of documents whose URI contains delimiter of query string literal

### DIFF
--- a/src/main/java/com/_4dconcept/springframework/data/marklogic/core/MarklogicTemplate.java
+++ b/src/main/java/com/_4dconcept/springframework/data/marklogic/core/MarklogicTemplate.java
@@ -222,7 +222,6 @@ public class MarklogicTemplate implements MarklogicOperations, ApplicationEventP
         String uri = retrieveUri(entity);
         if (uri != null) {
             LOGGER.debug("Remove '{}' from '{}'", entity, uri);
-            // Double the delimiter of string literal to allow its inclusion in said string literal
             String query = "xdmp:document-delete('" + uri.replace("'", "''") + "')";
             invokeAdhocQuery(query, new MarklogicInvokeOperationOptions() {
 

--- a/src/main/java/com/_4dconcept/springframework/data/marklogic/core/MarklogicTemplate.java
+++ b/src/main/java/com/_4dconcept/springframework/data/marklogic/core/MarklogicTemplate.java
@@ -222,7 +222,10 @@ public class MarklogicTemplate implements MarklogicOperations, ApplicationEventP
         String uri = retrieveUri(entity);
         if (uri != null) {
             LOGGER.debug("Remove '{}' from '{}'", entity, uri);
-            invokeAdhocQuery("xdmp:document-delete('" + uri + "')", new MarklogicInvokeOperationOptions() {
+            // Double the delimiter of string literal to allow its inclusion in said string literal
+            String query = "xdmp:document-delete('" + uri.replace("'", "''") + "')";
+            invokeAdhocQuery(query, new MarklogicInvokeOperationOptions() {
+
                 @Override
                 public boolean useCacheResult() {
                     return false;


### PR DESCRIPTION
Fix deletion of documents whose URI contains the delimiter of delete query literal string : double the delimiter for allowing its inclusion (see https://www.w3.org/TR/xquery-31/#id-literals)